### PR TITLE
json parsing process now controls for non-printable ascii characters

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -23,8 +23,9 @@ export function generate(src: string = conf.apiFile, dest: string = conf.outDir)
     const content = fs.readFileSync(src);
     schema = JSON.parse(content.toString());
   } catch (e) {
-    if (e instanceof SyntaxError) out(`${src} is not a valid JSON scheme`, 'red');
-    else out(`JSON scheme file '${src}' does not exist`, 'red');
+    if (e instanceof SyntaxError) {
+      out(`${src} is either not a valid JSON scheme or contains non-printable characters`, 'red');
+    } else out(`JSON scheme file '${src}' does not exist`, 'red');
 
     out(`${e}`);
     return;


### PR DESCRIPTION
I encountered a swagger file which could not be processed. It turned out it contained special characters, which could not be processed by JSON.parse