### PR TITLE
Publish dist directory only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
   - docker build -t swagger-angular-generator .
 
 script:
-  - docker run -it swagger-angular-generator bash -c "npm i; npm test"
+  - docker run -it swagger-angular-generator bash -c "npm i; npm run demo:install; npm test"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "main": "dist/generate.js",
   "types": "dist/generate.d.ts",
   "bin": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "postinstall": "cd demo-app/client && npm i",
+    "demo:install": "cd demo-app/client && npm i",
     "start": "ts-node src/index.ts",
     "start:debug": "node -r ts-node/register --inspect-brk src/index.ts",
     "prebuild": "rm -rf dist",


### PR DESCRIPTION
- Published package contains all files, this PR changes it so only `dist` is published, making the package smaller
- Demo install is done on each client install, this PR changes it so demo install is done separately