### PR TITLE
Ignore options methods in a swagger def

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -208,3 +208,7 @@ export function getAccessor(key: string, propName = '') {
 export function getObjectPropSetter(key: string, propName: string, suffix = '') {
   return `${getAccessor(key)}: ${getAccessor(key, propName)}${suffix},`;
 }
+
+export function isMethodName(method : string): boolean {
+  return ['get' , 'patch' , 'post' ,'put' , 'delete'].includes(method)
+}

--- a/src/requests/process-controller.ts
+++ b/src/requests/process-controller.ts
@@ -13,6 +13,8 @@ import {indent, writeFile} from '../utils';
 import {processMethod} from './process-method';
 import {processResponses} from './process-responses';
 import {ControllerMethod, MethodOutput} from './requests.models';
+import {isMethodName} from '../common'
+
 
 /**
  * Creates and serializes class for api communication for controller
@@ -36,7 +38,9 @@ export function processController(methods: ControllerMethod[], name: string, con
     usesGlobalType = usesGlobalType || controller.responseDef.usesGlobalType;
   });
 
-  const processedMethods: MethodOutput[] = methods.map(m => processMethod(m, config.unwrapSingleParamMethods));
+  const processedMethods: MethodOutput[] = methods
+    .filter(m => isMethodName(m.methodName)) //filter out all the unknown methods (like options)
+    .map(m => processMethod(m, config.unwrapSingleParamMethods));
   usesGlobalType = usesGlobalType || processedMethods.some(c => c.usesGlobalType);
 
   let content = '';


### PR DESCRIPTION
I have added a filter in front of the map function that generates each method. This filter removes the methods that are not configured. My only current example is a 'options' method that is needed for CORS support. 